### PR TITLE
Move the relevant sections under The Proposal heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,15 @@ Specification: https://maps4html.org/MapML/spec/
 
 <h2>Author</h2>
 
-
 Peter Rushforth
 
 <h2>Participate</h2>
-
 
 The W3C [Maps for HTML Community Group](https://www.w3.org/community/maps4html/) is iterating on the problem space.  You can contribute to the on-going discussion and documentation of [Use Cases and Requirements for Web mapping](https://maps4html.org/HTML-Map-Element-UseCases-Requirements/). Alternatively, if your organization is a member of the [Web Platform Incubator Community Group](https://www.w3.org/community/WICG/) (WICG) and you are able to contribute there but not elsewhere, please consider contributing through the [WICG forum on Web mapping](https://discourse.wicg.io/c/web-mapping/22).  We would love to hear from you. 
 
 [Issue tracker for this explainer](https://github.com/Maps4HTML/MapML-Proposal/issues)
 
-
-
-
 <h2 id="introduction">Introduction</h2>
-
 
 Web maps are a well-established domain of Web design, and there exist popular, mature open and closed source JavaScript libraries to create and manage Web maps.  JavaScript web maps are often containers for publicly available and funded open geospatial and statistical data.  Yet despite established JavaScript libraries and server-side API standards, Web maps remain a complex Web niche that is difficult to learn, due to their extensive prerequisite knowledge requirements. As a result, there exists a community of Web map developers which contributes very little to the Web platform and which may possess little understanding that the Web exists as a distinct and standards-based platform. Similarly, the Web platform seems mostly oblivious to Web maps and their requirements, and provides no direct support for maps. In other words, Web maps existence in the Web platform depends on intermediaries which “abstract away” the Web platform.  
 
@@ -28,10 +22,10 @@ The goal of this proposal is to bridge the gap between the two communities in a 
 
 - [The Problem](#the-problem)
 - [The Proposal](#the-proposal)
-- [Goals](#goals)
-- [Non-Goals](#non-goals)
-- [A High-Level API](#a-high-level-api)
-- [Key Scenarios](#key-scenarios)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+  - [A High-Level API](#a-high-level-api)
+  - [Key Scenarios](#key-scenarios)
 - [Detailed design discussion](#detailed-design-discussion)
   - [Use Cases and Requirements](#use-cases-and-requirements)
   - [W3C/OGC Joint Workshop on Maps for the Web](#w3c-ogc-joint-workshop-on-maps-for-the-web)
@@ -40,15 +34,13 @@ The goal of this proposal is to bridge the gap between the two communities in a 
 - [Stakeholder Feedback / Opposition](#stakeholder-feedback--opposition)
 - [References and Acknowledgements](#references-and-acknowledgements)
 
-<h3 id="the-problem">The Problem</h3>
-
+<h2 id="the-problem">The Problem</h2>
 
 Web maps today are created using a wide range of technology stacks on both the client and server, some standard, some open, and some proprietary.  The complexity of choices and the wide variety of technologies required to create Web maps results in <a href="https://github.com/Malvoz/web-maps-wcag-evaluation/blob/master/README.md">maps of highly variable usability and accessibility</a>.  This has in turn led to the creation of centralized mapping services, that may or may not be implemented using Web technology; in some cases, mapping services which work well on desktop Web browsers mostly bypass the mobile Web through creation of mobile platform mapping apps, where the ‘rules of the Web platform’ (such as device permissions) do not apply.  Some centralized mapping services, both on the Web but especially on mobile technology platforms, are constructed for the purpose of tracking the user’s location and their locations of (search) interest, and using that private location information to market and re-sell highly targeted advertising. 
 
 The problem to be solved, therefore, is to reduce the threshold complexity of creating accessible, usable and privacy-preserving Web maps, and to enable full use of Web platform standards such as HTML, URL, SVG, CSS and JavaScript in map creation, styling, presentation and interaction. 
 
-<h3 id="the-proposal">The Proposal</h3>
-
+<h2 id="the-proposal">The Proposal</h2>
 
 To solve <a href="#the-problem">the problem</a>, our approach is to identify the Web map processing that is currently performed by JavaScript libraries which should instead be defined - in accordance with the <a href="https://www.w3.org/TR/html-design-principles/">HTML Design Principles</a> - as elements and attributes supported by CSS, while at the same time, we identify the Web map processing that should remain in the JavaScript domain as a standardized DOM API. By building the core behaviour of maps and layers into HTML, Web authors who want to build simple maps into their pages can easily do so, supported by core platform technologies, with the power of JavaScript available to enhance the core map and layer behaviour.
 
@@ -58,22 +50,31 @@ In improving the choices among mapping services available through the Web platfo
 
 <h3 id="goals">Goals</h3>
 
-
-
-
-*   Define the means to allow authors to create dynamic, usable and accessible Web maps about as easily as they can embed an image, a video or a podcast today.
-*   Define and embed accessibility of map feature and location information into HTML for use by screen readers and other assistive technology.
-*   Define and design security of map information considerations into the Web platform.
-*   Define the markup to create mapping mashups that doesn’t necessarily require scripting or detailed mapping server technology knowledge i.e. that can be accomplished about as easily as linking to a document.
-*   Simplify the use of public spatial data infrastructures (SDI), such as OpenStreetMap and national and international SDIs, by designing the integration of those services into the proposed Web platform mapping standards.
-*   Defining and (advocate for) adding map-enabled HTML to the serialization formats available from existing spatial (map) content management systems, APIs and Web Services.
+- Define the means to allow authors to create dynamic,
+usable and accessible Web maps about as easily as they can embed an image,
+a video or a podcast today.
+- Define and embed accessibility of map feature and location information into
+HTML for use by screen readers and other assistive technology.
+- Define and design security of map information considerations into the Web
+platform.
+- Define the markup to create mapping mashups that doesn’t necessarily require
+scripting or detailed mapping server technology knowledge
+i.e. that can be accomplished about as easily as linking to a document.
+- Simplify the use of public spatial data infrastructures (SDI),
+such as OpenStreetMap and national and international SDIs,
+by designing the integration of those services into the proposed Web platform
+mapping standards.
+- Defining and (advocate for) adding map-enabled HTML to the serialization
+formats available from existing spatial (map) content management systems,
+APIs and Web Services.
 
 <h3 id="non-goals">Non-goals</h3>
 
-
-
-
-*   Interoperability with the operating model or availability of existing spatial (map) content management systems, APIs and Web Services. For example, the evolving <a href="https://ogcapi.ogc.org/"><abbr title="Open Geospatial Consortium">OGC</abbr> API</a> standards.
+- Interoperability with the operating model or availability of existing spatial
+(map) content management systems, APIs and Web Services.
+For example, the evolving
+<a href="https://ogcapi.ogc.org/"><abbr title="Open Geospatial Consortium">OGC</abbr> API</a>
+standards.
 
 <h3 id="a-high-level-api">A High-Level API</h3>
 
@@ -90,7 +91,7 @@ The proposed extension would create a standard `<map>` widget that contains cont
 
 *See the [High-Level API explainer](high-level-api.md) for details on the proposed elements that may be referred to in this proposal.*
 
-<h2 id="key-scenarios">Key Scenarios</h2>
+<h3 id="key-scenarios">Key Scenarios</h3>
 
 *See the [Key Scenarios explainer](high-level-api.md) detailing:*
 
@@ -120,24 +121,21 @@ See the [Report on the Joint W3C-OGC Workshop on Maps for the Web](https://www.w
 
 <h2 id="considered-alternative-designs-of-mapml">Considered alternative designs of MapML</h2>
 
-
 TBD - we have considered many alternatives, I have just run out of steam to document them, at the moment. Also this document is already quite long.  As things progress, I will add content here.
 
-<h3 id="alternative-approaches">Alternative Approaches</h3>
+<h2 id="alternative-approaches">Alternative Approaches</h2>
 
-*   [SVGMap](https://discourse.wicg.io/t/vector-tiling-on-svgmap/3135) - is it possible to merge the SVGMap proposal and this proposal? Or are they competing proposals?
-*   APIs: [Leaflet](https://leafletjs.com/), [OpenLayers](https://openlayers.org/) and others, (albeit others without any notion of cross-origin resource sharing) provide excellent map scripting APIs and events.  Can these or similar APIs be built on top of the proposed HTML infrastructure? Would life be simpler for authors with the proposed HTML?
-*   Status quo
+- [SVGMap](https://discourse.wicg.io/t/vector-tiling-on-svgmap/3135) - is it possible to merge the SVGMap proposal and this proposal? Or are they competing proposals?
+- APIs: [Leaflet](https://leafletjs.com/), [OpenLayers](https://openlayers.org/) and others, (albeit others without any notion of cross-origin resource sharing) provide excellent map scripting APIs and events.  Can these or similar APIs be built on top of the proposed HTML infrastructure? Would life be simpler for authors with the proposed HTML?
+- Status quo
 
 <h2 id="stakeholder-feedback-opposition">Stakeholder Feedback / Opposition</h2>
-
 
 Some participants have said we should start over, because of the [sunk costs fallacy](https://en.m.wikipedia.org/wiki/Sunk_cost#Concorde_effect); that doesn’t seem to be in the spirit of iteration, nor hopefully is it correct to see this proposal as a waste of energy or money.  A better strategy would be to solicit concrete, actionable and incremental change requests.  It is in that spirit that the current explainer is offered. 
 
 The objective of this project is to get Web browser projects to agree that Web maps as a high level feature are desirable and that the proposal is implementable, and _then_ to implement and ship the feature.  To get there from here, we need browser developer participation, the absence of which appears equivalent to opposition. So, there is work to do.
 
 <h2 id="references-and-acknowledgements">References and Acknowledgements</h2>
-
 
 Contributions, advice and support from the following people are gratefully acknowledged:
 


### PR DESCRIPTION
Structurally, this:
> - The Problem
> - The Proposal
> - Goals
> - Non-Goals
> - A High-Level API
> - Key Scenarios
> - ...

becomes:
> - The Problem
> - The Proposal
>   - Goals
>   - Non-Goals
>   - A High-Level API
>   - Key Scenarios
> - ...

(Also corrects heading levels, removes a bit of unnecessary white-space/new-lines, and uses `-` uniformly for lists as opposed to `*`.)